### PR TITLE
Add 'Skip to Cursor' action to editor context menu

### DIFF
--- a/src/main/kotlin/org/jetbrains/plugins/jumpToLine/JumpToStatementAction.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/jumpToLine/JumpToStatementAction.kt
@@ -2,7 +2,6 @@ package org.jetbrains.plugins.jumpToLine
 
 import com.intellij.debugger.engine.JavaDebugProcess
 import com.intellij.debugger.ui.JavaDebuggerSupport
-import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.project.Project
@@ -69,13 +68,6 @@ private class DummyActionHandler : DebuggerActionHandler() {
 
 class JumpToStatementAction : XDebuggerActionBase(true) {
     
-    override fun update(event: AnActionEvent) {
-        super.update(event)
-        if (event.place == ActionPlaces.EDITOR_POPUP) {
-            event.presentation.text = "Skip to Here"
-        }
-    }
-
     override fun isEnabled(e: AnActionEvent?): Boolean {
         val project = e?.project ?: return false
         return XDebuggerManager.getInstance(project).currentSession?.isSuspended ?: false

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,7 @@
       <keyboard-shortcut first-keystroke="control alt shift F9" keymap="$default"/>
       <keyboard-shortcut first-keystroke="meta shift F10" keymap="Visual Studio OSX" replace-all="true"/>
       <add-to-group group-id="DebuggingActionsGroup" anchor="after" relative-to-action="ForceRunToCursor"/>
+      <add-to-group group-id="EditorPopupMenuDebug" anchor="after" relative-to-action="ForceRunToCursor"/>
     </action>
   </actions>
 


### PR DESCRIPTION
Hi, I figured it'd be useful if the plugin automatically added 'Skip to Cursor' to the editor context menu, so that users don't have to do it themselves.

I also noticed that the action title changes to 'Skip to Here' in this context menu, but it looked inconsistent with the existing 'Run to Cursor' actions so I reverted it. If you want to keep it the way it is, let me know and I'll undo the change.

![obrazek](https://user-images.githubusercontent.com/3685160/102725868-3ad23f00-431a-11eb-9326-69162a98621b.png)
